### PR TITLE
Add link to BrowserStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,3 +272,6 @@ This starts a server and listens on port 8080 for connections. The app send api 
 * Controllers - The controllers handles all the logic behind validating request parameters, query, Sending Responses with correct codes.
 * Services - The services contains the database queries and returning objects or throwing errors
 
+#### Cross-Browser Testing 
+
+Cross-browser testing is done via [BrowserStack](https://www.browserstack.com).


### PR DESCRIPTION
In order to apply for free access to BrowserStack, a link on one's Github page is required.