### PR TITLE
Add BrowserStack logo without text

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,4 @@ This starts a server and listens on port 8080 for connections. The app send api 
 #### Cross-Browser Testing 
 
 Cross-browser testing is done via [BrowserStack](https://www.browserstack.com).
+<img src="https://raw.githubusercontent.com/jonathantneal/browserstack-app/master/assets/icon.png" width="20">


### PR DESCRIPTION
Add BrowserStack logo without text, per requirements to apply for a free BrowserStack license (for open source projects).